### PR TITLE
feat: improve tool call UI with icons and previews

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,38 @@
+# Plan: Enhance Deep Agents UI for Sub-Agent Debugging
+
+## Current Implementation
+- `ChatInterface` processes messages and renders `ChatMessage` components.
+- `ChatMessage` displays message text and tool calls through `ToolCallBox`; sub-agent creation tool calls (`name === "task"`) are hidden from the tool call list and instead summarized with `SubAgentIndicator`.
+- `ToolCallBox` collapses tool call details and only shows tool name and status icon in the header.
+- Stakeholders currently must expand each tool call or sub-agent card to see arguments and results.
+
+## Goals
+- Make tool calls visually distinct so their purpose is clear without expansion.
+- Surface details about sub-agent creation and outputs directly in the chat stream.
+- Provide richer debugging information for stakeholders without cluttering the interface.
+
+## Proposed Improvements
+1. **Tool Call Metadata & Icons**
+   - Create a utility mapping tool names to icons and badge colors (e.g., search, file, sub-agent).
+   - Update `ToolCallBox` header to render the mapped icon and apply color styling based on tool type.
+2. **Preview Arguments/Results in Header**
+   - Add truncated snippets of key arguments or the first line of results directly in the collapsed header of `ToolCallBox`.
+   - Display timestamps or duration if available in tool call metadata.
+3. **Specialized Sub-Agent Call Rendering**
+   - For `toolCall.name === "task"`, replace the generic `ToolCallBox` with a `SubAgentToolCallBox`:
+     - Show sub-agent name, description, and status icon in the collapsed view.
+     - Include a one-line summary of the sub-agent's output.
+     - Allow expansion to reveal full input/output similar to `SubAgentPanel`.
+   - Visually nest subsequent tool calls executed by the sub-agent beneath its parent indicator.
+4. **Group and Filter Tool Calls**
+   - Provide controls to expand/collapse all tool calls or filter by tool name or sub-agent within the chat view.
+   - Consider a side panel summarizing all sub-agents and their tool calls for quick navigation.
+5. **Styling & UX Enhancements**
+   - Update SCSS modules for `ToolCallBox`, `SubAgentIndicator`, and related components to support new icons, colors, and nested layout.
+   - Ensure keyboard accessibility for new interactive elements.
+6. **Documentation**
+   - Document new debugging features and usage in `README.md` once implemented.
+
+## Testing
+- After implementation, run `npm run lint` and `npm test` to verify code quality and future tests.
+

--- a/src/app/components/ToolCallBox/ToolCallBox.module.scss
+++ b/src/app/components/ToolCallBox/ToolCallBox.module.scss
@@ -44,6 +44,11 @@
   color: var(--color-text-primary);
 }
 
+.toolIcon {
+  width: 14px;
+  height: 14px;
+}
+
 .description {
   font-size: $font-size-sm;
   color: var(--color-text-secondary);

--- a/src/app/components/ToolCallBox/ToolCallBox.tsx
+++ b/src/app/components/ToolCallBox/ToolCallBox.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import styles from "./ToolCallBox.module.scss";
 import { ToolCall } from "../../types/types";
+import { getToolMeta } from "../../utils/toolMeta";
 
 interface ToolCallBoxProps {
   toolCall: ToolCall;
@@ -20,7 +21,7 @@ interface ToolCallBoxProps {
 export const ToolCallBox = React.memo<ToolCallBoxProps>(({ toolCall }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const { name, args, result, status } = useMemo(() => {
+  const { name, args, result, status, meta, preview } = useMemo(() => {
     const toolName = toolCall.name || "Unknown Tool";
     const toolArgs = toolCall.args || "{}";
     let parsedArgs = {};
@@ -32,12 +33,34 @@ export const ToolCallBox = React.memo<ToolCallBoxProps>(({ toolCall }) => {
     }
     const toolResult = toolCall.result || null;
     const toolStatus = toolCall.status || "completed";
+    const toolMeta = getToolMeta(toolName);
+    const previewText = (() => {
+      if (toolResult) {
+        const str =
+          typeof toolResult === "string"
+            ? toolResult
+            : JSON.stringify(toolResult);
+        return str.split("\n")[0].slice(0, 50);
+      }
+      const argKeys = Object.keys(parsedArgs);
+      if (argKeys.length > 0) {
+        const key = argKeys[0];
+        const val =
+          typeof parsedArgs[key] === "string"
+            ? parsedArgs[key]
+            : JSON.stringify(parsedArgs[key]);
+        return `${key}: ${val}`.slice(0, 50);
+      }
+      return "";
+    })();
 
     return {
       name: toolName,
       args: parsedArgs,
       result: toolResult,
       status: toolStatus,
+      meta: toolMeta,
+      preview: previewText,
     };
   }, [toolCall]);
 
@@ -76,7 +99,14 @@ export const ToolCallBox = React.memo<ToolCallBoxProps>(({ toolCall }) => {
             <ChevronRight size={14} />
           )}
           {statusIcon}
+          <meta.icon
+            className={styles.toolIcon}
+            style={{ color: meta.color }}
+          />
           <span className={styles.toolName}>{name}</span>
+          {preview && (
+            <span className={styles.description}>{preview}</span>
+          )}
         </div>
       </Button>
 

--- a/src/app/utils/toolMeta.ts
+++ b/src/app/utils/toolMeta.ts
@@ -1,0 +1,18 @@
+import { Search, FileText, Bot, Terminal } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export interface ToolMeta {
+  icon: LucideIcon;
+  color: string;
+}
+
+const TOOL_META: Record<string, ToolMeta> = {
+  search: { icon: Search, color: "var(--color-primary)" },
+  file: { icon: FileText, color: "var(--color-secondary)" },
+  task: { icon: Bot, color: "var(--color-accent)" },
+};
+
+export const getToolMeta = (name: string): ToolMeta => {
+  return TOOL_META[name] || { icon: Terminal, color: "var(--color-text-tertiary)" };
+};
+


### PR DESCRIPTION
## Summary
- add tool metadata mapping for icons and colors
- display tool icons and argument/result previews in ToolCallBox
- document future UI enhancements in plan

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8eaffdad48324895293274b7ad162